### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ jobs:
   publish:
     name: Publish
     runs-on: linux
-    if: false && github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) # <- This make sure the workflow is skipped without any alert
+    if: github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) # <- This make sure the workflow is skipped without any alert
     steps:
     - uses: actions/checkout@v4
     - name: Build


### PR DESCRIPTION
This pull request includes a modification to the `publish` job in the GitHub Actions workflow configuration to ensure the job runs on pushes to the `master` or `main` branches.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L7-R7): Removed the condition `false &&` from the `if` statement, allowing the workflow to run on push events to the `master` or `main` branches.