### PR TITLE
Centralizes shell regex escaping for paths

### DIFF
--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -64,11 +64,14 @@ export const cleanupPuppeteerBrowsers = ( ) => {
       // Find processes using 'firefox' or 'chrome' that have '--user-data-dir'
       // pointing to our expected browser-data directory OR the specific launch ID.
       // Use 'grep -F' for fixed string matching and 'grep -v grep' to exclude the grep process itself
-      const command =
-        `ps aux | grep -E '[c]hrome|[f]irefox' | ` +
-        `grep -E -- '-user-data-dir=.+${escapedDataDir}' | ${LAUNCH_ID_ARG}' | awk '{print $2}'`
-      const output = execSync ( command, { encoding: "utf8" } )
-      pidsToKill = output.trim ( ).split ( os.EOL ).filter ( Boolean )
+      const args = [
+        "aux",
+        "|", "grep", "-E", "'[c]hrome|[f]irefox'",
+        "|", "grep", "-E", `-- '-user-data-dir=.+${escapedDataDir}' | ${LAUNCH_ID_ARG}`,
+        "|", "awk", "'{print $2}'"
+      ]
+      const output = spawnSync ( "ps", args, { encoding: "utf8" } )
+      pidsToKill = output.stdout.trim ( ).split ( os.EOL ).filter ( Boolean )
     }
 
     if ( pidsToKill.length === 0 ) {


### PR DESCRIPTION
Introduces a dedicated helper function to consistently escape backslashes and forward slashes in file paths for shell regular expressions.

Ensures the `BROWSER_DATA_DIR` is correctly matched in both `powershell` and `grep` commands during the browser cleanup process, improving reliability and maintainability by centralizing the escaping logic.
