### PR TITLE
Adds 1.8.2 entry to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
+# 1.8.2 (2025-10-29)
 # 1.8.1 (2025-10-29)
 - Refactor cleanup of data directory. Only create if specifically asked for.
 - Destroy only old pids created by this run of quick-pdf.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iqx-limited/quick-pdf",
-  "version": "1.9.0",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iqx-limited/quick-pdf",
-      "version": "1.9.0",
+      "version": "1.8.2",
       "license": "MIT",
       "dependencies": {
         "file-type": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iqx-limited/quick-pdf",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "author": "IQX",
   "description": "Converting PDFs to images (📃 to 📸)",
   "type": "module",


### PR DESCRIPTION
Adds a new version heading for `1.8.2` to the `CHANGELOG.md` file. This prepares the release documentation for the upcoming version.